### PR TITLE
docs(cli/known-issues.md): fix incorrect helm uninstall command

### DIFF
--- a/docs/for-ops/cli/known-issues.md
+++ b/docs/for-ops/cli/known-issues.md
@@ -113,5 +113,5 @@ helm -n <namespace> rollback <release-name> <previous revision number>
 Otherwise, if there is a helm release in the state `pending` AND it has only one revision, then remove that release:
 
 ```
-helm uninstall -n <namespace> rollback <release-name>
+helm uninstall -n <namespace> <release-name>
 ```


### PR DESCRIPTION
The previous version of the documentation contained an incorrect helm uninstall command. The updated version removes the unnecessary "rollback" keyword, providing the correct command for uninstalling a helm release.