### PR TITLE
Upgraded actions and node version

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -12,10 +12,10 @@ jobs:
     name: Deploy to GitHub Pages
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions/setup-node@v3
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
         with:
-          node-version: 16.x
+          node-version: 20
           cache: npm
 
       - name: Install dependencies


### PR DESCRIPTION
#49 fails to deploy, as the GitHub actions in their older version do not support the newer required Node version. This PR adjusts the versions.