### PR TITLE
fix: Set trailingSlash explicitly to false

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -194,6 +194,7 @@ module.exports = {
       ],
     },
   },
+  trailingSlash: false,
   presets: [
     [
       isBootstrapPreset


### PR DESCRIPTION
According to [Docusaurus deployment docs](https://docusaurus.io/docs/deployment#deploying-to-github-pages) this setting is recommended, since with the default (undefined), GitHub pages adds trailing slashes.