### PR TITLE
feat: add sealed secrets docs

### DIFF
--- a/docs/apps/sealedsecrets.md
+++ b/docs/apps/sealedsecrets.md
@@ -1,0 +1,42 @@
+---
+slug: sealed-secrets
+title: Sealed Secrets
+sidebar_label: Sealed Secrets
+---
+
+Encrypt your Secret into a SealedSecret, which is safe to store - even inside a public repository.
+
+## Overview
+
+[Bitnami Sealed Secrets](https://github.com/bitnami-labs/sealed-secrets) is a controller that allows you to encrypt your kubernetes secrets and store them in a secure manner, even in public repositories. The controller works by encrypting your secret into a SealedSecret, which can only be decrypted by the sealed secrets controller in your cluster.
+
+## Bring your own certificates
+
+:::info AlERT
+You can use your certificates for the disaster recovery purpose. Please make sure to download encryption keys.
+:::
+
+While the controller generates its own certificates upon deployment, you also have the option to bring your own certificates. This allows the controller to consume certificates from a secret labeled with `sealedsecrets.bitnami.com/sealed-secrets-key=active`. The Secret should reside in the `sealed-secrets` namespace, which must be the same as the controller's namespace. You can have multiple secrets with this label.
+
+To configure the certificates, add the following to the `values.yaml` when installing Otomi:
+
+```yaml
+bootstrap:
+  apiVersion: v1
+  items:
+    - apiVersion: v1
+      data:
+        tls.crt: <tls-crt>
+        tls.key: <tls-key>
+      kind: Secret
+      metadata:
+        generateName: sealed-secrets-key
+        labels:
+          sealedsecrets.bitnami.com/sealed-secrets-key: active
+        name: <sealed-secrets-name>
+        namespace: sealed-secrets
+      type: kubernetes.io/tls
+  kind: List
+```
+
+Make sure to replace `<tls-crt>`, `<tls-key>`, `<sealed-secrets-name>` with your actual certificate data and sealed secrets name.

--- a/docs/apps/sealedsecrets.md
+++ b/docs/apps/sealedsecrets.md
@@ -21,6 +21,9 @@ While the controller generates its own certificates upon deployment, you also ha
 To configure the certificates, add the following to the `values.yaml` when installing Otomi:
 
 ```yaml
+apps:
+  sealed-secrets:
+    enabled: true
 bootstrap:
   apiVersion: v1
   items:

--- a/product/architecture.md
+++ b/product/architecture.md
@@ -57,6 +57,7 @@ Otomi Core is the heart of Otomi and contains a suite of the following integrate
 - [Cloudnative-pg](https://github.com/cloudnative-pg/cloudnative-pg): Open source operator designed to manage PostgreSQL workloads
 - [Grafana Tempo](https://github.com/grafana/tempo): High-scale distributed tracing backend
 - [OpenTelemetry](https://github.com/open-telemetry/opentelemetry-operator): Instrument, generate, collect, and export telemetry data to help you analyze your software’s performance and behavior
+- [Sealed Secrets](https://github.com/bitnami-labs/sealed-secrets): Encrypt your Secret into a SealedSecret, which is safe to store - even inside a public repository.
 
 ### Catagories
 

--- a/sidebar-docs.js
+++ b/sidebar-docs.js
@@ -5,7 +5,7 @@ module.exports = {
       "get-started/promo",
       "get-started/prerequisites",
       {
-        "Installation": [
+        Installation: [
           "get-started/installation/overview",
           "get-started/installation/aws",
           "get-started/installation/azure",
@@ -22,7 +22,7 @@ module.exports = {
           "get-started/installation/kms",
           "get-started/installation/entrypoint",
           "get-started/installation/byo-wildcard",
-        ]
+        ],
       },
       "get-started/activation",
       {
@@ -178,6 +178,7 @@ module.exports = {
       "apps/minio",
       "apps/otel",
       "apps/prometheus",
+      "apps/sealedsecrets",
       "apps/thanos",
       "apps/trivy",
       "apps/tekton",
@@ -189,4 +190,4 @@ module.exports = {
     //   "tutorials/tutorial-1",
     // ],
   },
-};
+}


### PR DESCRIPTION
### Implements:
https://app.zenhub.com/workspaces/dev-5e7e84dddc966f05a627a19b/issues/gh/redkubes/otomi-core/1441
https://github.com/bitnami-labs/sealed-secrets

### Description:
This PR adds a documentation page for the new sealed secrets feature.
Is paired with: 
https://github.com/redkubes/otomi-core/pull/1463
https://github.com/redkubes/otomi-api/pull/500
https://github.com/redkubes/otomi-console/pull/381