### PR TITLE
fix: recommend to use app secret

### DIFF
--- a/docs/get-started/labs/lab-24.md
+++ b/docs/get-started/labs/lab-24.md
@@ -16,25 +16,26 @@ You can create a postgresql database from the developer catalog:
 4. Change other parameter values as required
 5. Click `Submit` and the `Deploy Changes`
 
-The operator will now create the database and add a secret to the team's namespace called `<database-name>-superuser`. This secret contains the username and password for the database with the keys `username` and `password`.
+The operator will now create the database and add secrets to the team's namespace called `<database-name>-superuser` and `<database-name>-app`. `<database-name>-superuser` contains the secrets for the superuser of the PostgreSQL cluster, whereas the `<database-name>-app` is granted access to the default database with the name set for the database. Each secret contains the username and password for the database with the keys `username` and `password`.
 
 You can now provide the username and password to a container as environment variables using a `secretKeyRef`:
 
 ```yaml
 env:
-- name: DB_PASSWORD
-  valueFrom:
-    secretKeyRef:
-      name: <database-name>-superuser
-      key: password
-- name: SECRET_KEY
-  valueFrom:
-    secretKeyRef:
-      name: <database-name>-superuser
-      key: username
+  - name: DB_PASSWORD
+    valueFrom:
+      secretKeyRef:
+        name: <database-name>-app
+        key: password
+  - name: SECRET_KEY
+    valueFrom:
+      secretKeyRef:
+        name: <database-name>-app
+        key: username
 ```
+
+> Note: Using the superuser credentials for connecting an app is discouraged. The app user has the access it needs for initializing tables etc.
 
 ## Monitoring
 
 The `postgresql` quick start template includes two parameters that can be used to create a `PodMonitor` and a Grafana Dashboard. Set the `monitoring` parameter to `true` to create a PodMonitor and set the `dashboard` parameter to `true` to add a cloudnativepg dashboard to the Team's Grafana. Note that this dashboard can be used to monitor multiple databases so you'll just need to create it once.
-


### PR DESCRIPTION
When creating a PostgreSQL cluster using the app catalog, there are two secrets, `<database-name>-superuser` and `<database-name>-app`. The latter should be preferred for connecting apps to it.