### PR TITLE
fix: add instruction to activate the Otel app

### DIFF
--- a/docs/get-started/labs/lab-27.md
+++ b/docs/get-started/labs/lab-27.md
@@ -11,6 +11,7 @@ In order to make a system observable, it must be instrumented. Language specific
 For this lab it is required to:
 
 - Enable `Tempo`
+- Enable `Otel`
 - Enable tracing for `Istio` and `Nginx Ingress`
 
 ## Build an image from source code


### PR DESCRIPTION
When activating `Tempo` for tracing, `Otel` is not automatically activated. Without the app, deploying using the workload catalog template fails. This PR adds the instruction to activate the Otel app.