### PR TITLE
feat: update network policies lab

### DIFF
--- a/.cspell.json
+++ b/.cspell.json
@@ -92,7 +92,7 @@
     "petclinic",
     "cnpg",
     "pgdata",
-    "favourite"
+    "favourite",
     "WPUE",
     "wsbtpg",
     "uxqf"

--- a/.cspell.json
+++ b/.cspell.json
@@ -50,6 +50,7 @@
     "mkdir",
     "mkilled",
     "mysecret",
+    "nicolaka",
     "nofollow",
     "noindex",
     "ojson",
@@ -92,6 +93,9 @@
     "cnpg",
     "pgdata",
     "favourite"
+    "WPUE",
+    "wsbtpg",
+    "uxqf"
   ],
   "language": "en",
   "words": [
@@ -149,6 +153,7 @@
     "owasp",
     "postgres",
     "prio",
+    "rabbitmq",
     "rbac",
     "redkubes",
     "rego",

--- a/docs/get-started/labs/lab-19.md
+++ b/docs/get-started/labs/lab-19.md
@@ -13,25 +13,23 @@ In some cases you want to explicitly allow access to your application. This can 
 
 The internal ingress network policies allow you to:
 
-- Deny all traffic to the Pods of a Workload (default)
+- Deny all traffic to Pods (default mode)
 - Allow selected Workload Pods running on the cluster to access your Workload's Pods
 - Allow all traffic to the Pods of a Workload
 
 `Deny all` and `Allow all` we don't need to explain right?
 
 :::info
-The Ingress Network Policies in Otomi rely on the `otomi.io/app` label. All Workloads in Otomi need to use this label. 
-When you're using an Otomi quick start template from the Catalog, this label is always added.
+The Ingress Network Policies in Otomi rely on Pod labels. We require that a single label covers Pods for a given workload. We recommend to use the `otomi.io/app: <workload-name>` label.
 :::
 
 To allow other Workloads in the cluster to access your Workload's Pods, follow these steps:
 
-- Register your Workload's Kubernetes ClusterIP service as a Service in Otomi. If public ingress isn't needed, select the `Private` Exposure option.
 - Navigate to the `Network Policies` page in the Otomi Console and click `Create Netpol`.
 - Name the network policy and select the `ingress` rule type.
-- Add the selector label name and value for the Workload Pods to be accessed. Use the `otomi.io/app` label value.
+- Add the selector label name and value for the Workload Pods to be accessed. E.g.: use the `otomi.io/app` label.
 - Select either `AllowAll` or `AllowOnly` mode.
-- If you select `AllowOnly`, specify the namespace (e.g., `team-labs`), and the selector label name and value for the Workload Pods to be accessed. Again, use the `otomi.io/app` label value.
+- If you select `AllowOnly`, specify the namespace (e.g., `team-labs`), and the selector label name and value for the Workload Pods to be accessed.
 - Add more rules if needed.
 
 ## Understanding Egress Network Policies
@@ -48,13 +46,17 @@ To allow your Workload's Pods to access external FQDNs or IPs, follow these step
 - Add the FQDN or IP to be accessed.
 - Add port number(s) and protocol if needed.
 
+:::info
+The egress rules are namespace wide. You cannot bind egress policy to a given workload only.
+:::
+
 ## Setting Up Network Policies for the Example Voting App: An Ingress Example
 
 ### Build Images for the Application
 
 Build the `Vote`, `Worker` and `Result` images from this [repo](https://github.com/redkubes/example-voting-app).
 
-Use the Build feature in Otomi to build the images with `mode-Docker`. Set the `path` to `./vote/Dockerfile` for the Vote image (and `./worker/Dockerfile` for the Worker and `./result/Dockerfile` for Result).
+Use the Build feature in Otomi to build the images with `mode: Docker`. Set the `path` to `./vote/Dockerfile` for the Vote image (and `./worker/Dockerfile` for the Worker and `./result/Dockerfile` for Result).
 
 ### Create a Redis Cluster and a PostgreSQL Database
 
@@ -139,7 +141,7 @@ env:
 
 #### Redis
 
-- Register the `<workload-name>-master` Redis service. 
+- Register the `<workload-name>-master` Redis service.
 - Set exposure to `Private` (default).
 
 #### Vote

--- a/docs/get-started/labs/lab-19.md
+++ b/docs/get-started/labs/lab-19.md
@@ -187,14 +187,13 @@ env:
 - Name the network policy `otomi` and select the `egress` rule type.
 - Add the FQDN `otomi.io` to be accessed.
 - Add port number `443` and protocol `HTTPS`.
-- Add port number `80` and protocol `HTTP`.
 
 ### Deploy Netshoot Pod
 
-- Deploy a Netshoot pod in your Kubernetes cluster.
+- Deploy a Netshoot pod in your namespace within your Kubernetes cluster.
 - You can do this using kubectl command:
   ```shell
-  kubectl run -i --tty --rm netshoot --image nicolaka/netshoot --restart=Never
+  kubectl run -i --tty --rm netshoot --image nicolaka/netshoot -n team-labs
   ```
 
 :::info
@@ -205,7 +204,7 @@ The [Netshoot](https://github.com/nicolaka/netshoot) pod is a network troublesho
 
 - Run the following command in the Netshoot pod:
   ```shell
-  curl -v https://otomi.io
+  curl https://otomi.io
   ```
 - You should see the HTML of the Otomi.io website.
 - Run the following command to see the `<h1>Build, Deploy and Run applications at scale</h1>` message:

--- a/docs/get-started/labs/lab-19.md
+++ b/docs/get-started/labs/lab-19.md
@@ -9,50 +9,58 @@ In some cases you want to explicitly allow access to your application. This can 
 - Policies for ingress traffic inside the cluster
 - Policies for egress traffic to go outside of the cluster (to access external FQDNs)
 
-## About network policies for internal ingress
+## Understanding Internal Ingress Network Policies
 
-The internal ingress network policies alllow you to:
+The internal ingress network policies allow you to:
 
-- Deny all traffic to the Pods of a Workload
+- Deny all traffic to the Pods of a Workload (default)
 - Allow selected Workload Pods running on the cluster to access your Workload's Pods
+- Allow all traffic to the Pods of a Workload
 
 `Deny all` and `Allow all` we don't need to explain right?
 
 :::info
-The Ingress Network Policies in Otomi rely on the `otomi.io/app` label. All Workloads in Otomi need to use this label. When your using an Otomi quick start template from the Catalog, this label is always added.
+The Ingress Network Policies in Otomi rely on the `otomi.io/app` label. All Workloads in Otomi need to use this label. 
+When you're using an Otomi quick start template from the Catalog, this label is always added.
 :::
 
-To allow other Workloads on the cluster to access your Workload's Pods, do the following:
+To allow other Workloads in the cluster to access your Workload's Pods, follow these steps:
 
-**If the `ClusterIP` service of your workload has the same name as the `otomi.io/app` label value:**
+- Register your Workload's Kubernetes ClusterIP service as a Service in Otomi. If public ingress isn't needed, select the `Private` Exposure option.
+- Navigate to the `Network Policies` page in the Otomi Console and click `Create Netpol`.
+- Name the network policy and select the `ingress` rule type.
+- Add the selector label name and value for the Workload Pods to be accessed. Use the `otomi.io/app` label value.
+- Select either `AllowAll` or `AllowOnly` mode.
+- If you select `AllowOnly`, specify the namespace (e.g., `team-labs`), and the selector label name and value for the Workload Pods to be accessed. Again, use the `otomi.io/app` label value.
+- Add more rules if needed.
 
-- Register the Kubernetes ClusterIP service of the Workload as a Service in Otomi. If no public ingress is required, then just use the `Private` Exposure option
-- In the `Network policies` section leave the `PodSelector` field blanc
-- In the `Ingress traffic inside the cluster` select `Allow selected`
-- Add the team name (without `team-`) and `otomi.io/app` label value of the Workload Pods that are allowed access
+## Understanding Egress Network Policies
 
-**If the `ClusterIP` service of your workload does NOT have the same name as the `otomi.io/app` label value:**
+The egress network policies allow you to:
 
-This is sometimes the case when a Workload has multiple `ClusterIP` services. In this scenario you will only need to configure the network policies in one of the Workload services. 
+- Deny all traffic from the Pods of a Workload (default)
+- Allow all Pods within a namespace to access external FQDNs or IPs through an egress rule.
 
-- Register the Kubernetes ClusterIP service of the Workload as a Service in Otomi. If no public ingress is required, then just use the `Private` Exposure option
-- In the `Network policies` section leave the `PodSelector` add the `PodSelector`. Use a custom value for the "otomi.io/app:" label.
-- In the `Ingress traffic inside the cluster` select `Allow selected`
-- Add the team name (without `team-`) and `otomi.io/app` label value of the Workload Pods that are allowed access
+To allow your Workload's Pods to access external FQDNs or IPs, follow these steps:
 
-## Configure network policies for the Example Voting App
+- Navigate to the `Network Policies` page in the Otomi Console and click `Create Netpol`.
+- Name the network policy and select the `egress` rule type.
+- Add the FQDN or IP to be accessed.
+- Add port number(s) and protocol if needed.
 
-### Building the images
+## Setting Up Network Policies for the Example Voting App: An Ingress Example
+
+### Build Images for the Application
 
 Build the `Vote`, `Worker` and `Result` images from this [repo](https://github.com/redkubes/example-voting-app).
 
 Use the Build feature in Otomi to build the images with `mode-Docker`. Set the `path` to `./vote/Dockerfile` for the Vote image (and `./worker/Dockerfile` for the Worker and `./result/Dockerfile` for Result).
 
-### Create a Redis cluster and a PostgreSQL database
+### Create a Redis Cluster and a PostgreSQL Database
 
 Use the `postgresql` and the `redis` charts from the Catalog to create a Redis master-replica cluster and a PostgreSQL database. For this lab, Redis authentication needs to be turned off by setting `auth.enabled=false`.
 
-### Deploy the Vote app
+### Deploy the Vote App
 
 Use the `k8s-deployment` chart to deploy the vote app. Use the following values:
 
@@ -68,7 +76,7 @@ env:
     value: <redis-cluster-name>-master
 ```
 
-### Deploy the Worker app
+### Deploy the Worker App
 
 Use the `k8s-deployment` chart to deploy the worker app. Use the following values:
 
@@ -96,7 +104,7 @@ env:
     value: <psql-cluster-name>-rw
 ```
 
-### Deploy the Result app
+### Deploy the Result App
 
 Use the `k8s-deployment` chart to deploy the result app. Use the following values:
 
@@ -122,39 +130,87 @@ env:
     value: <psql-cluster-name>-rw
 ```
 
-### Register the services for Exposure and configure network policies
+### Register the Services for Exposure
 
-#### Postgres database
+#### Postgres Database
 
-- Register the `<workload-name>-rw` Postgresql service
-- Set exposure to `Private` (default)
-- In `Network policies` add the Pod Selector `<postgres-workload-name>`
-- Select `Allow selected`
-- Add From team name `<team-name>` and From label value `<postgres-workload-name>`
-- Add From team name `<team-name>` and From label value `<worker>`
-- Add From team name `<team-name>` and From label value `<result>`
+- Register the `<workload-name>-rw` Postgresql service.
+- Set exposure to `Private` (default).
 
 #### Redis
 
-- Register the `<workload-name>-master` Redis service 
-- Set exposure to `Private` (default)
-- In `Network policies` add the Pod Selector `<redis-workload-name>`
-- Select `Allow selected`
-- Add From team name `<team-name>` and From label value `<redis-workload-name>`
-- Add From team name `<team-name>` and From label value `<worker>`
-- Add From team name `<team-name>` and From label value `<vote>`
+- Register the `<workload-name>-master` Redis service. 
+- Set exposure to `Private` (default).
 
 #### Vote
 
-- Register the `vote` service 
-- Set exposure to `External`
+- Register the `vote` service.
+- Set exposure to `External`.
 
 #### Result
 
-- Register the `<result>` service 
-- Set exposure to `External`
+- Register the `<result>` service.
+- Set exposure to `External`.
 
-### Test the app
+### Register the Network Policies for the Example Voting App
 
-Go to the external URL of the `vote` application. Click on `Cats` or `Dogs`. Now go to the external URL of the `result` application. You should see the result of your vote.
+#### Postgres Database
 
+- Create a new `Netpol` and select the `ingress` rule type.
+- Add the selector label name `otomi.io/app`.
+- Add the selector label value `<postgres-workload-name>`.
+- Select `AllowOnly`.
+- Add the namespace `<team-name>`, the selector label name `otomi.io/app` and the selector label value `<worker>`.
+- Add the namespace `<team-name>`, the selector label name `otomi.io/app` and the selector label value `<result>`.
+
+#### Redis
+
+- Create a new `Netpol` and select the `ingress` rule type.
+- Add the selector label name `otomi.io/app`.
+- Add the selector label value `<redis-workload-name>`.
+- Select `AllowOnly`.
+- Add the namespace `<team-name>`, the selector label name `otomi.io/app` and the selector label value `<worker>`.
+- Add the namespace `<team-name>`, the selector label name `otomi.io/app` and the selector label value `<vote>`.
+
+### Test the Voting App
+
+- Go to the external URL of the `vote` application.
+- Click on `Cats` or `Dogs`.
+- Now go to the external URL of the `result` application.
+- You should see the result of your vote.
+
+## Setting Up Network Policies for Otomi.io: An Egress Example
+
+### Register the Network Policy for Otomi.io
+
+- Navigate to the `Network Policies` page in the Otomi Console and click `Create Netpol`.
+- Name the network policy `otomi` and select the `egress` rule type.
+- Add the FQDN `otomi.io` to be accessed.
+- Add port number `443` and protocol `HTTPS`.
+- Add port number `80` and protocol `HTTP`.
+
+### Deploy Netshoot Pod
+
+- Deploy a Netshoot pod in your Kubernetes cluster.
+- You can do this using kubectl command:
+  ```shell
+  kubectl run -i --tty --rm netshoot --image nicolaka/netshoot --restart=Never
+  ```
+
+:::info
+The [Netshoot](https://github.com/nicolaka/netshoot) pod is a network troubleshooting tool that includes a lot of network tools like `curl`, `dig`, `nslookup`, `ping`, `traceroute`, etc.
+:::
+
+### Test the Egress Network Policy
+
+- Run the following command in the Netshoot pod:
+  ```shell
+  curl -v https://otomi.io
+  ```
+- You should see the HTML of the Otomi.io website.
+- Run the following command to see the `<h1>Build, Deploy and Run applications at scale</h1>` message:
+  ```shell
+  curl https://otomi.io | grep -o '<h1>.*</h1>'
+  ```
+- Type `exit` to exit the Netshoot pod.
+- When you exit the Netshoot pod, it will be removed from the cluster.


### PR DESCRIPTION
### Implements:
https://app.zenhub.com/workspaces/dev-5e7e84dddc966f05a627a19b/issues/gh/redkubes/otomi-core/1493

### Description:
This PR updates the network policies lab for the new network policies feature and adds a new egress example in the lab.

otomi-core: https://github.com/redkubes/otomi-core/pull/1503
otomi-api: https://github.com/redkubes/otomi-api/pull/502
otomi-console: https://github.com/redkubes/otomi-console/pull/386