### PR TITLE
feat: add docs for GCS/Loki setup

### DIFF
--- a/docs/apps/loki.md
+++ b/docs/apps/loki.md
@@ -6,6 +6,37 @@ sidebar_label: Loki
 
 Loki aggregates all the container logs from the platform and stores them in a storage endpoint of choice (defaults to PVC). When Otomi is installed in multi-tenancy mode (see [here](../for-ops/console/settings/otomi.md)) it will split logs from team namespaces and make them available only to team members. Otomi provides shortcuts to selections of logs based on interest. Otomi splits logs per team, installs a dedicated Grafana instance per team and configures authentication for Grafana to allow access for team members only.
 
+## Setup with GCS
+
+When using Google Cloud Storage as a backend in combination with Google Kubernetes Engine, authentication can be set up using workload identity federation. The following instructions provide a service account, that can be set in the `serviceAccount` field when selecting the GCS option for Loki storage.
+
+1. Make sure the cluster supports the feature. It needs to be activated on the cluster as well as each node pool. This will possibly require draining nodes temporarily, so account for extra capacity. Follow the instructions in the [GKE docs](https://cloud.google.com/kubernetes-engine/docs/how-to/workload-identity) to set up the required API and update cluster and node pool. Follow the rest of the instructions below.
+2. Create a GCS storage bucket to use for Loki, if possible in the same project as the Otomi cluster.
+3. Create a IAM service account. Note that the project name should match the project of the storage bucket and the GKE cluster. This is not strictly required, but cross-project access may have to be granted separately.
+
+   ```
+   gcloud iam service-accounts create $SA_NAME --project=$PROJECT
+   ```
+
+4. Grant the role access to your storage bucket.
+
+   ```
+   gcloud projects add-iam-policy-binding $PROJECT \
+   --member="serviceAccount:$SA_NAME@$PROJECT.iam.gserviceaccount.com" \
+   --project $PROJECT \
+   --role="roles/storage.objectAdmin"
+   ```
+
+5. Create a policy binding, allowing resources with the Kubernetes ServiceAccount to impersonate the IAM service account:
+
+   ```
+   gcloud iam service-accounts add-iam-policy-binding --project $PROJECT $SA_NAME \
+   --role roles/iam.workloadIdentityUser \
+   --member "serviceAccount:$PROJECT.svc.id.goog[monitoring/loki]"
+   ```
+
+6. Provide the service account in the GCS storage values for Loki, in the full notation `$SA_NAME@$PROJECT.iam.gserviceaccount.com` and deploy.
+
 ## Known issues
 
 ### Time Range does not show all data
@@ -17,4 +48,3 @@ In a data driven application that has pagination, when a user selects a time win
 **Solution:**
 
 When you don't see enough data, try increasing the line limit. The maximum is configurable in the Loki values.
-


### PR DESCRIPTION
Depends on redkubes/otomi-core#1556 and redkubes/otomi-api#509